### PR TITLE
Read template `popup.wflow` from the same directory as `index.js`.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 'use strict';
 var fs = require('fs');
+var path = require('path')
 var execFile = require('child_process').execFile;
-var tpl = fs.readFileSync('popup.wflow', 'utf8');
+var tpl = fs.readFileSync(path.resolve(__dirname, 'popup.wflow'), 'utf8');
 var tempWrite = require('temp-write');
 
 module.exports = function (opts, cb) {


### PR DESCRIPTION
The CLI wasn't finding `popup.wflow` unless I was in `/usr/local/lib/node_modules/website-popup/`.

> ``` shell
> ~ $ website-popup 'https://google.com' --size 800x600
> fs.js:443
>   return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
>                  ^
> Error: ENOENT, no such file or directory 'popup.wflow'
>     at Error (native)
>     at Object.fs.openSync (fs.js:443:18)
>     at Object.fs.readFileSync (fs.js:309:15)
>     at Object.<anonymous> (/usr/local/lib/node_modules/website-popup/index.js:4:14)
>     at Module._compile (module.js:449:26)
>     at Object.Module._extensions..js (module.js:467:10)
>     at Module.load (module.js:349:32)
>     at Function.Module._load (module.js:305:12)
>     at Module.require (module.js:357:17)
>     at require (module.js:373:17)
> ```
